### PR TITLE
Add sample for testing against Salem's parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ These files are used as sample data in xwrf testing suites, tutorials, and docum
 
 - [`dummy.nc`](./data/dummy.nc): A dummy file for testing purposes
 - [`dummy_attrs_only.nc`](./data/dummy_attrs_only.nc): A dummy file with only attributes for testing purposes
+- [`dummy_salem_parsed.nc`](./data/dummy_salem_parsed.nc): `dummy.nc` as parsed by [Salem](https://github.com/fmaussion/salem) for testing purposes
 - [`geo_em_d01_polarstereo.nc`](./data/geo_em_d01_polarstereo.nc): polar stereographic sample from [Salem](https://github.com/fmaussion/salem-sample-data/blob/master/salem-test/grid/geo_em_d01_polarstereo.nc?rgh-link-date=2022-02-07T21%3A50%3A37Z)
 - [`geo_em_d02_polarstereo.nc`](./data/geo_em_d02_polarstereo.nc): polar stereographic with inner nest sample from [Salem](https://github.com/fmaussion/salem-sample-data/blob/master/salem-test/grid/geo_em_d02_polarstereo.nc?rgh-link-date=2022-02-07T21%3A50%3A37Z)
 - [`lambert_conformal_sample.nc`](./data/lambert_conformal_sample.nc): Retrieved from <https://api.blika.is/static/wrfout_example.nc>

--- a/sha256_checksums.json
+++ b/sha256_checksums.json
@@ -1,6 +1,7 @@
 {
   "dummy.nc": "6e05226406066da86773c76023eafb727e9540577c90c0c7f95e01eaf19c7208",
   "dummy_attrs_only.nc": "6c71252146bc2ef791d5205046985a39e7eb4779de4319077a9dba8b89cd082b",
+  "dummy_salem_parsed.nc": "23b2ec44aa76cd088cee1369fa5409d409ba2ff7efca98c50b538f0a16f2fedb",
   "geo_em_d01_polarstereo.nc": "120335893e74adf1e85ec459f58bf5d63aca109041bff71b0814d898cf173251",
   "geo_em_d02_polarstereo.nc": "c230d1a788e501c8853588b8b6fb198e5090e880f33969d534b749da8fa0f1d7",
   "lambert_conformal_sample.nc": "bef3b92a2bff65e84d8073e08409a17209468b786e6e2b03102e4ad28c3da36c",


### PR DESCRIPTION
This was previously [`sample-data/wrfout_d03_2012-04-22_23_00_00_subset_parsed_by_salem.nc`](https://github.com/ncar-xdev/xwrf/blob/c4aaf96e934b2dd8aeac21d8c99899d5d5713026/tests/sample-data/wrfout_d03_2012-04-22_23_00_00_subset_parsed_by_salem.nc) from https://github.com/ncar-xdev/xwrf/pull/14. I'd like to add this for limited direct tests against Salem's parsing results (otherwise, most tests of the projection coordinate values will be checked by verifying that they can accurately recreate the existing lat/lon values, which is the approach Salem takes it its own tests).
